### PR TITLE
added so_term column to biotype

### DIFF
--- a/modules/ORM/EnsEMBL/DB/Production/Object/Biotype.pm
+++ b/modules/ORM/EnsEMBL/DB/Production/Object/Biotype.pm
@@ -59,7 +59,8 @@ __PACKAGE__->meta->setup(
                             no_group
                             undefined)]
     },
-    so_acc            => {type => 'varchar', 'length' => 64 }
+    so_acc            => {type => 'varchar', 'length' => 64 },
+    so_term           => {type => 'varchar', 'length' => 1023 }
   ],
 
   trackable             => 1,


### PR DESCRIPTION
New column (so_term) added to master_biotype table.

Pull request to production to follow.

Target release 97.